### PR TITLE
Renamed tags no longer include errant comma

### DIFF
--- a/spec/converter_spec.cr
+++ b/spec/converter_spec.cr
@@ -222,6 +222,13 @@ describe HTML2Lucky::Converter do
     input = "<div <p>></p>"
     HTML2Lucky::Converter.new(input).convert
   end
+
+  it "treats renamed tags as non-custom tags" do
+    input = "<p>Hello</p>"
+    output = HTML2Lucky::Converter.new(input).convert
+
+    output.should eq_html %q(para "Hello")
+  end
 end
 
 private def eq_html(html)

--- a/src/tags/tag.cr
+++ b/src/tags/tag.cr
@@ -1,8 +1,10 @@
 require "myhtml"
 
 abstract class HTML2Lucky::Tag
-  QUOTE = '"'
-  NAMED_TAGS = Lucky::BaseTags::TAGS + Lucky::BaseTags::EMPTY_TAGS
+  QUOTE      = '"'
+  NAMED_TAGS = Lucky::BaseTags::TAGS +
+               Lucky::BaseTags::EMPTY_TAGS +
+               Lucky::BaseTags::RENAMED_TAGS.values.to_a
 
   getter depth, tag
 
@@ -71,9 +73,9 @@ abstract class HTML2Lucky::Tag
 
   def squish(string : String)
     two_or_more_whitespace = /\s{2,}/
-    string.gsub(two_or_more_whitespace, " ").
-      gsub(/\A\s+/, " ").
-      gsub(/\s+\Z/, " ")
+    string.gsub(two_or_more_whitespace, " ")
+      .gsub(/\A\s+/, " ")
+      .gsub(/\s+\Z/, " ")
   end
 
   private def wrap_quotes(string : String) : String


### PR DESCRIPTION
Turns out when you have a custom tag, the tag will be printed out with an extra comma to join it to the arguments. For example:

```crystal
para "Hello, world!", class: "main"

tag "custom", "Hello, world!", class: "main"
```

`p` (and `select`) were not being included in the list of non-custom tags. They were listed under RENAMED_TAGS inside Lucky. Including their tag values in the list of tags was the fix.

fixes #7